### PR TITLE
Added POST users/toggleInstructor endpoint and tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
@@ -71,4 +71,8 @@ public abstract class ApiController {
     });
     return mapper;
   }
+
+  protected Object genericMessage(String message) {
+    return Map.of("message", message);
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
@@ -53,11 +53,11 @@ public class UsersController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
     public User postUsersToggleInstructor(
-            @Parameter(name="githubId") @RequestParam Integer id)
+            @Parameter(name="githubId") @RequestParam Integer githubId)
             {
 
-        User user = userRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+        User user = userRepository.findByGithubId(githubId)
+                .orElseThrow(() -> new EntityNotFoundException(User.class, githubId));
 
         user.setInstructor(!user.isInstructor());
 

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
@@ -51,7 +51,7 @@ public class UsersController extends ApiController {
 
     @Operation(summary= "Toggle a user's instructor status")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PostMapping("/post")
+    @PostMapping("/toggleInstructor")
     public User postUsersToggleInstructor(
             @Parameter(name="githubId") @RequestParam Integer githubId)
             {

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
@@ -68,6 +68,7 @@ public class UsersController extends ApiController {
 
         userRepository.save(user);
         return genericMessage("User with githubId %s has toggled instructor status to %s".formatted(githubId, user.isInstructor()));
+    }
 
     @Operation(summary = "Toggle the admin field")
     @PreAuthorize("hasRole('ROLE_ADMIN')")

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
@@ -7,13 +7,27 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.organic.errors.EntityNotFoundException;
 import edu.ucsb.cs156.organic.entities.User;
+import edu.ucsb.cs156.organic.entities.UserEmail;
 import edu.ucsb.cs156.organic.repositories.UserRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.time.Instant;
+
+import javax.validation.Valid;
 
 @Tag(name = "User information (admin only)")
 @RequestMapping("/api/admin/users")
@@ -33,5 +47,21 @@ public class UsersController extends ApiController {
         Iterable<User> users = userRepository.findAll();
         String body = mapper.writeValueAsString(users);
         return ResponseEntity.ok().body(body);
+    }
+
+    @Operation(summary= "Toggle a user's instructor status")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public User postUsersToggleInstructor(
+            @Parameter(name="githubId") @RequestParam Integer id)
+            {
+
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+        user.setInstructor(!user.isInstructor());
+
+        User savedUser = userRepository.save(user);
+        return user;
     }
 }

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
@@ -7,32 +7,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.PathVariable;
 
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import edu.ucsb.cs156.organic.errors.EntityNotFoundException;
 import edu.ucsb.cs156.organic.entities.User;
-import edu.ucsb.cs156.organic.entities.UserEmail;
 import edu.ucsb.cs156.organic.repositories.UserRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-
-import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
-import java.time.Instant;
-
-import javax.validation.Valid;
-
 
 @Tag(name = "User information (admin only)")
 @RequestMapping("/api/admin/users")

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
@@ -52,7 +52,7 @@ public class UsersController extends ApiController {
     @Operation(summary= "Toggle a user's instructor status")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/toggleInstructor")
-    public User postUsersToggleInstructor(
+    public Object postUsersToggleInstructor(
             @Parameter(name="githubId") @RequestParam Integer githubId)
             {
 
@@ -61,7 +61,7 @@ public class UsersController extends ApiController {
 
         user.setInstructor(!user.isInstructor());
 
-        User savedUser = userRepository.save(user);
-        return savedUser;
+        userRepository.save(user);
+        return genericMessage("User with githubId %s has toggled instructor status to %s".formatted(githubId, user.isInstructor()));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
@@ -62,6 +62,6 @@ public class UsersController extends ApiController {
         user.setInstructor(!user.isInstructor());
 
         User savedUser = userRepository.save(user);
-        return user;
+        return savedUser;
     }
 }

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
@@ -25,6 +25,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
 
 @WebMvcTest(controllers = UsersController.class)
@@ -71,7 +72,6 @@ public class UsersControllerTests extends ControllerTestCase {
   public void users__instructor_toggle_false_to_true() throws Exception {
 
     // arrange
-
     User u1 = User.builder()
       .email("cgaucho@ucsb.edu")
       .githubId(1)
@@ -87,22 +87,17 @@ public class UsersControllerTests extends ControllerTestCase {
     when(userRepository.findByGithubId(eq(1))).thenReturn(Optional.of(u1));
     when(userRepository.save(eq(u1Toggled))).thenReturn(u1Toggled);
 
-    String expectedJson = mapper.writeValueAsString(u1Toggled);
-
     // act
-
     MvcResult response = mockMvc.perform(
       post("/api/admin/users/toggleInstructor?githubId=1")
       .with(csrf()))
       .andExpect(status().isOk()).andReturn();
 
     // assert
-
     verify(userRepository, times(1)).findByGithubId(1);
     verify(userRepository, times(1)).save(u1Toggled);
-    String responseString = response.getResponse().getContentAsString();
-    assertEquals(expectedJson, responseString);
-
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("User with githubId 1 has toggled instructor status to true", json.get("message"));
   }
 
   @WithMockUser(roles = { "ADMIN", "USER" })
@@ -110,7 +105,6 @@ public class UsersControllerTests extends ControllerTestCase {
   public void users__instructor_toggle_true_to_false() throws Exception {
 
     // arrange
-
     User u1 = User.builder()
       .email("cgaucho@ucsb.edu")
       .githubId(1)
@@ -126,22 +120,17 @@ public class UsersControllerTests extends ControllerTestCase {
     when(userRepository.findByGithubId(eq(1))).thenReturn(Optional.of(u1));
     when(userRepository.save(eq(u1Toggled))).thenReturn(u1Toggled);
 
-    String expectedJson = mapper.writeValueAsString(u1Toggled);
-
     // act
-
     MvcResult response = mockMvc.perform(
       post("/api/admin/users/toggleInstructor?githubId=1")
       .with(csrf()))
       .andExpect(status().isOk()).andReturn();
 
     // assert
-
     verify(userRepository, times(1)).findByGithubId(1);
     verify(userRepository, times(1)).save(u1Toggled);
-    String responseString = response.getResponse().getContentAsString();
-    assertEquals(expectedJson, responseString);
-
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("User with githubId 1 has toggled instructor status to false", json.get("message"));
   }
 
   @WithMockUser(roles = { "ADMIN", "USER" })
@@ -159,5 +148,8 @@ public class UsersControllerTests extends ControllerTestCase {
 
     // assert
     verify(userRepository, times(1)).findByGithubId(1);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("User with id 1 not found", json.get("message"));
+  
   }
 }

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
@@ -99,7 +99,9 @@ public class UsersControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("User with githubId 1 has toggled instructor status to true", json.get("message"));
   }
-
+  
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
   public void admin_can_toggle_admin_status_of_a_user_from_false_to_true() throws Exception {
           // arrange
           User userBefore = User.builder()
@@ -165,6 +167,8 @@ public class UsersControllerTests extends ControllerTestCase {
     assertEquals("User with githubId 1 has toggled instructor status to false", json.get("message"));
   }
 
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
   public void admin_can_toggle_admin_status_of_a_user_from_true_to_false() throws Exception {
           // arrange
           User userBefore = User.builder()
@@ -215,7 +219,9 @@ public class UsersControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("User with id 1 not found", json.get("message"));
   }
-  
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
   public void admin_tries_to_toggleAdmin_non_existant_user_and_gets_right_error_message() throws Exception {
           // arrange
         

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
@@ -99,6 +99,7 @@ public class UsersControllerTests extends ControllerTestCase {
     verify(userRepository, times(1)).save(u1Toggled);
     Map<String, Object> json = responseToJson(response);
     assertEquals("User with githubId 1 has toggled instructor status to true", json.get("message"));
+  }
 
   public void admin_can_toggle_admin_status_of_a_user_from_false_to_true() throws Exception {
           // arrange

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
@@ -164,6 +164,7 @@ public class UsersControllerTests extends ControllerTestCase {
     verify(userRepository, times(1)).save(u1Toggled);
     Map<String, Object> json = responseToJson(response);
     assertEquals("User with githubId 1 has toggled instructor status to false", json.get("message"));
+  }
 
   public void admin_can_toggle_admin_status_of_a_user_from_true_to_false() throws Exception {
           // arrange
@@ -214,6 +215,7 @@ public class UsersControllerTests extends ControllerTestCase {
     verify(userRepository, times(1)).findByGithubId(1);
     Map<String, Object> json = responseToJson(response);
     assertEquals("User with id 1 not found", json.get("message"));
+  }
   
   public void admin_tries_to_toggleAdmin_non_existant_user_and_gets_right_error_message() throws Exception {
           // arrange

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
@@ -15,7 +15,6 @@ import edu.ucsb.cs156.organic.testconfig.TestConfig;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
This PR adds an endpoint to toggle a user's instructor status, with corresponding tests.

Closes #4

<img width="812" alt="image" src="https://github.com/ucsb-cs156-f23/proj-organic-f23-6pm-4/assets/54901977/111467c6-426b-4422-9151-d4e5ea88ab33">
