### PR TITLE
Fixing Typo In Footer

### DIFF
--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -5,7 +5,7 @@ export default function Footer({systemInfo}) {
     <footer className="bg-light pt-3 pt-md-4 pb-4 pb-md-5">
       <Container>
         <p data-testid="footer-content">
-          Organic is a project of 
+          Organic is a project of{' '} 
           <a href="https://ucsb-cs156.github.io">CS156</a>, 
           a course at UC Santa Barbara.  It's purpose: provide students and instructors with useful tools to manage
           Github organizations associated with programming and software engineering courses.

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -1,7 +1,7 @@
 import { Container } from "react-bootstrap";
 
 export default function Footer({systemInfo}) {
-  return (
+  return ( 
     <footer className="bg-light pt-3 pt-md-4 pb-4 pb-md-5">
       <Container>
         <p data-testid="footer-content">

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -8,7 +8,7 @@ describe("Footer tests", () => {
             <Footer systemInfo={systemInfoFixtures.showingAll}/>
         );
 
-        const expectedText = "Organic is a project ofCS156, a course at UC Santa Barbara.  It's purpose: provide students and instructors with useful tools to manage Github organizations associated with programming and software engineering courses. The open source code is available on GitHub.";
+        const expectedText = "Organic is a project of CS156, a course at UC Santa Barbara.  It's purpose: provide students and instructors with useful tools to manage Github organizations associated with programming and software engineering courses. The open source code is available on GitHub.";
 
         
         const text = screen.getByTestId("footer-content");

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -4,7 +4,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 describe("Footer tests", () => {
     test("renders correctly", async () => {
-        render(
+        render( 
             <Footer systemInfo={systemInfoFixtures.showingAll}/>
         );
 


### PR DESCRIPTION
In this PR, we fixed the footer so that there is no longer a typo. It now says "Organic is a project of CS156" instead of "Organic is a project ofCS156"

Deployed at: https://proj-organic-allychu-dev.dokku-08.cs.ucsb.edu

Closes #17 