### PR TITLE
cs - Issue #11/F1: Created Schools Table and Tests

### DIFF
--- a/frontend/src/main/components/School/SchoolsTable.js
+++ b/frontend/src/main/components/School/SchoolsTable.js
@@ -48,7 +48,7 @@ export default function SchoolsTable({
         },
         {
             Header: 'Term Error',
-            id: 'termError',
+            accessor: 'termError',
         }
     ];
 

--- a/frontend/src/main/components/School/SchoolsTable.js
+++ b/frontend/src/main/components/School/SchoolsTable.js
@@ -1,0 +1,65 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/schoolUtils"
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function SchoolsTable({
+    schools,
+    currentUser,
+    testIdPrefix = "SchoolsTable" }) {
+
+    const navigate = useNavigate();
+
+    const editCallback = (cell) => {
+        navigate(`/schools/edit/${cell.row.values.abbrev}`)
+    }
+
+    // Stryker disable all : hard to test for query caching
+
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/schools/all"]
+    );
+    // Stryker restore all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+    const columns = [
+        {
+            Header: 'Abbreviation',
+            accessor: 'abbrev',
+        },
+        {
+            Header: 'Name',
+            accessor: 'name',
+        },
+        {
+            Header: 'Term Regex',
+            accessor: 'termRegex',
+        },
+        {
+            Header: 'Term Description',
+            accessor: 'termDescription',
+        },
+        {
+            Header: 'Term Error',
+            id: 'termError',
+        }
+    ];
+
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+        columns.push(ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix));
+    } 
+
+    return <OurTable
+        data={schools}
+        columns={columns}
+        testid={testIdPrefix}
+    />;
+};

--- a/frontend/src/main/utils/schoolUtils.js
+++ b/frontend/src/main/utils/schoolUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+    console.log(message);
+    toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/schools",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.abbrev
+        }
+    }
+}

--- a/frontend/src/stories/components/School/SchoolsTable.stories.js
+++ b/frontend/src/stories/components/School/SchoolsTable.stories.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import SchoolsTable from 'main/components/School/SchoolsTable';
+import { schoolsFixtures } from 'fixtures/schoolsFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { rest } from "msw";
+
+export default {
+    title: 'components/School/SchoolsTable',
+    component: SchoolsTable
+};
+
+const Template = (args) => {
+    return (
+        <SchoolsTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    schools: []
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+    schools: schoolsFixtures.threeSchools,
+    currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+    schools: schoolsFixtures.threeSchools,
+    currentUser: currentUserFixtures.adminUser,
+}
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.delete('/api/schools', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+};

--- a/frontend/src/tests/components/School/SchoolsTable.test.js
+++ b/frontend/src/tests/components/School/SchoolsTable.test.js
@@ -1,0 +1,175 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { schoolsFixtures } from "fixtures/schoolsFixtures";
+import SchoolsTable from "main/components/School/SchoolsTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate
+}));
+
+describe("SchoolsTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = ["Abbreviation", "Name", "Term Regex", "Term Description", "Term Error"];
+  const expectedFields = ["abbrev", "name", "termRegex", "termDescription", "termError"];
+  const testId = "SchoolsTable";
+
+  test("renders empty table correctly", () => {
+    
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SchoolsTable schools={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SchoolsTable schools={schoolsFixtures.threeSchools} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-abbrev`)).toHaveTextContent("ucsb");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("UC Santa Barbara");
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-abbrev`)).toHaveTextContent("umn");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-name`)).toHaveTextContent("University of Minnesota");
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+
+  test("Has the expected column headers, content for ordinary user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.userOnly;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SchoolsTable schools={schoolsFixtures.threeSchools} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-abbrev`)).toHaveTextContent("ucsb");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("UC Santa Barbara");
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-abbrev`)).toHaveTextContent("umn");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-name`)).toHaveTextContent("University of Minnesota");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+
+  test("Edit button navigates to the edit page", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SchoolsTable schools={schoolsFixtures.threeSchools} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-abbrev`)).toHaveTextContent("ucsb");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("UC Santa Barbara");
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+
+    // act - click the edit button
+    fireEvent.click(editButton);
+
+    // assert - check that the navigate function was called with the expected path
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/schools/edit/ucsb'));
+
+  });
+
+  test("Delete button calls delete callback", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SchoolsTable schools={schoolsFixtures.threeSchools} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-abbrev`)).toHaveTextContent("ucsb");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("UC Santa Barbara");
+
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+
+    // act - click the delete button
+    fireEvent.click(deleteButton);
+  });
+});

--- a/frontend/src/tests/utils/schoolUtils.test.js
+++ b/frontend/src/tests/utils/schoolUtils.test.js
@@ -1,0 +1,53 @@
+import { onDeleteSuccess, cellToAxiosParamsDelete } from "main/utils/schoolUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("schoolUtils", () => {
+
+    describe("onDeleteSuccess", () => {
+
+        test("It puts the message on console.log and in a toast", () => {
+            // arrange
+            const restoreConsole = mockConsole();
+
+            // act
+            onDeleteSuccess("abc");
+
+            // assert
+            expect(mockToast).toHaveBeenCalledWith("abc");
+            expect(console.log).toHaveBeenCalled();
+            const message = console.log.mock.calls[0][0];
+            expect(message).toMatch("abc");
+
+            restoreConsole();
+        });
+
+    });
+    describe("cellToAxiosParamsDelete", () => {
+
+        test("It returns the correct params", () => {
+            // arrange
+            const cell = { row: { values: { abbrev: "ucsb" } } };
+
+            // act
+            const result = cellToAxiosParamsDelete(cell);
+
+            // assert
+            expect(result).toEqual({
+                url: "/api/schools",
+                method: "DELETE",
+                params: { id: "ucsb" }
+            });
+        });
+
+    });
+});


### PR DESCRIPTION
This PR adds a schools table, tests, stories, and school utils with tests.

Closes #49

Can't add storybook link until base branch is merged, but here are screenshots from local host:
**Empty Table**
<img width="560" alt="Screenshot 2023-11-28 at 4 00 39 PM" src="https://github.com/ucsb-cs156-f23/proj-organic-f23-6pm-4/assets/54901977/217e092d-6c55-440e-98e1-cd9df5cf9317">
**Three Items Ordinary User**
<img width="1082" alt="Screenshot 2023-11-29 at 12 00 48 PM" src="https://github.com/ucsb-cs156-f23/proj-organic-f23-6pm-4/assets/54901977/49fc9274-77f7-4d6d-a337-4172ed2d4b7c">
**Three Items Admin User**
<img width="1240" alt="Screenshot 2023-11-29 at 12 00 55 PM" src="https://github.com/ucsb-cs156-f23/proj-organic-f23-6pm-4/assets/54901977/37a32cfd-3895-4487-aa5a-364e6361501d">